### PR TITLE
kintone.app.record.getHeaderMenuSpaceElement is missing

### DIFF
--- a/kintone.d.ts
+++ b/kintone.d.ts
@@ -98,6 +98,7 @@ declare namespace kintone {
         namespace record {
             function getId(): number | null;
             function get() : any | null;
+            function getHeaderMenuSpaceElement(): HTMLElement | null;
             function getFieldElement(fieldCode: string) : HTMLElement | null;
             function set(record: any) : void;
             function getSpaceElement(id : string): HTMLElement | null;

--- a/src/integration-tests/dts-gen-api-test.ts
+++ b/src/integration-tests/dts-gen-api-test.ts
@@ -84,6 +84,7 @@ function assertKintoneBuiltinFunctions() {
     // assert function exists in kintone.app.record
     const r = kintone.app.record;
     assertFunction(r.get);
+    assertFunction(r.getHeaderMenuSpaceElement);
     assertFunction(r.getFieldElement);
     assertFunction(r.getId);
     assertFunction(r.getSpaceElement);


### PR DESCRIPTION
definition of kintone.app.record.getHeaderMenuSpaceElement  is missing

Ref: https://developer.cybozu.io/hc/ja/articles/201942014-%E3%83%AC%E3%82%B3%E3%83%BC%E3%83%89%E8%A9%B3%E7%B4%B0%E6%83%85%E5%A0%B1%E5%8F%96%E5%BE%97