### PR TITLE
fix: failed integration-tests

### DIFF
--- a/tsconfig.integration.json
+++ b/tsconfig.integration.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include" : [
+      "src/integration-tests/*.ts"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,14 @@ module.exports = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              configFile: 'tsconfig.integration.json'
+            },
+          }
+        ],
         exclude: /node_modules/
       }
     ]


### PR DESCRIPTION
Currently, `npm run build:integration` is failed because of type check errors.

```
TS2582: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.
```

`npm run build:integration` shouldn't include unit test files using Jest so I'll remove these files from build targets for `npm run build:integration`.