### PR TITLE
fix crash with Full Width Symbol in FieldCode

### DIFF
--- a/resources/test-fullwidth-symbol-field.d.ts
+++ b/resources/test-fullwidth-symbol-field.d.ts
@@ -1,0 +1,57 @@
+declare namespace kintone.types {
+  interface TestFields {
+    Record_number: {
+      type: "RECORD_NUMBER";
+      value: string;
+      error?: string;
+    };
+    "・": {
+      type: "SINGLE_LINE_TEXT";
+      value: string;
+      error?: string;
+    };
+    "＄": {
+      type: "SINGLE_LINE_TEXT";
+      value: string;
+      error?: string;
+    };
+    "￥": {
+      type: "SINGLE_LINE_TEXT";
+      value: string;
+      error?: string;
+    };
+    "＿": {
+      type: "SINGLE_LINE_TEXT";
+      value: string;
+      error?: string;
+    };
+  }
+  interface SavedTestFields extends TestFields {
+    $id: {
+      type: "__ID__";
+      value: string;
+    };
+    $revision: {
+      type: "__REVISION__";
+      value: string;
+    };
+    Updated_by: {
+      type: "MODIFIER";
+      value: { code: string; name: string };
+    };
+    Created_by: {
+      type: "CREATOR";
+      value: { code: string; name: string };
+    };
+    Updated_datetime: {
+      type: "UPDATED_TIME";
+      value: string;
+      error?: string;
+    };
+    Created_datetime: {
+      type: "CREATED_TIME";
+      value: string;
+      error?: string;
+    };
+  }
+}

--- a/src/kintone/clients/demo-fullwidth-symbol-client.ts
+++ b/src/kintone/clients/demo-fullwidth-symbol-client.ts
@@ -1,0 +1,20 @@
+import {
+    FetchFormPropertiesInput,
+    FormsClient,
+    FieldNameAndFieldOrSubTableField,
+} from "./forms-client";
+import { DemoDatas } from "./demo-fullwidth-symbols-datas";
+
+export class DemoFullWidthSymbolClient implements FormsClient {
+    fetchFormProperties(
+        _: FetchFormPropertiesInput
+    ): Promise<FieldNameAndFieldOrSubTableField> {
+        const demoResp = {
+            properties:
+                DemoDatas.DemoDataIncludingBuiltinFields,
+        };
+        return Promise.resolve(
+            demoResp.properties as FieldNameAndFieldOrSubTableField
+        );
+    }
+}

--- a/src/kintone/clients/demo-fullwidth-symbol-client.ts
+++ b/src/kintone/clients/demo-fullwidth-symbol-client.ts
@@ -5,7 +5,8 @@ import {
 } from "./forms-client";
 import { DemoDatas } from "./demo-fullwidth-symbols-datas";
 
-export class DemoFullWidthSymbolClient implements FormsClient {
+export class DemoFullWidthSymbolClient
+    implements FormsClient {
     fetchFormProperties(
         _: FetchFormPropertiesInput
     ): Promise<FieldNameAndFieldOrSubTableField> {

--- a/src/kintone/clients/demo-fullwidth-symbols-datas.ts
+++ b/src/kintone/clients/demo-fullwidth-symbols-datas.ts
@@ -1,0 +1,104 @@
+const DemoFullWidthSymbolDataFields: any = {
+    Nakaguro: {
+        type: "SINGLE_LINE_TEXT",
+        label: "・",
+        noLabel: "false",
+        code: "・",
+        required: "false",
+        expression: "",
+        hideExpression: "false",
+        unique: "false",
+        defaultValue: "",
+    },
+
+    FullWidthDollar: {
+        type: "SINGLE_LINE_TEXT",
+        label: "＄",
+        noLabel: "false",
+        code: "＄",
+        required: "false",
+        defaultValue: "",
+    },
+
+    FullWidthYen: {
+        type: "SINGLE_LINE_TEXT",
+        label: "￥",
+        noLabel: "false",
+        code: "￥",
+        required: "false",
+        defaultValue: "",
+    },
+
+    FullWidthUnderBar: {
+        type: "SINGLE_LINE_TEXT",
+        label: "＿",
+        noLabel: "false",
+        code: "＿",
+        required: "false",
+        defaultValue: "",
+    }
+};
+
+const DemoFullWidthSymbolRecord: any = {
+    Nakaguro: {
+        type: "SINGLE_LINE_TEXT",
+        value: "・",
+    },
+
+    FullWidthDollar: {
+        type: "SINGLE_LINE_TEXT",
+        value: "＄",
+    },
+
+    FullWidthYen: {
+        type: "SINGLE_LINE_TEXT",
+        value: "￥",
+    },
+
+    FullWidthUnderBar: {
+        type: "SINGLE_LINE_TEXT",
+        value: "＿",
+    },
+};
+
+const DemoDataBuiltinFields: any = {
+    Record_number: {
+        type: "RECORD_NUMBER",
+        label: "Record number",
+        noLabel: "false",
+        code: "Record_number",
+    },
+    Updated_by: {
+        type: "MODIFIER",
+        label: "Updated by",
+        noLabel: "false",
+        code: "Updated_by",
+    },
+    Created_by: {
+        type: "CREATOR",
+        label: "Created by",
+        noLabel: "false",
+        code: "Created_by",
+    },
+    Updated_datetime: {
+        type: "UPDATED_TIME",
+        label: "Updated datetime",
+        noLabel: "false",
+        code: "Updated_datetime",
+    },
+    Created_datetime: {
+        type: "CREATED_TIME",
+        label: "Created datetime",
+        noLabel: "false",
+        code: "Created_datetime",
+    },
+};
+
+export const DemoDatas = {
+    DemoFullWidthSymbolDataFields,
+    DemoDataIncludingBuiltinFields: Object.assign(
+        DemoDataBuiltinFields,
+        DemoFullWidthSymbolDataFields
+    ),
+    DemoFullWidthSymbolRecord,
+};

--- a/src/kintone/clients/demo-fullwidth-symbols-datas.ts
+++ b/src/kintone/clients/demo-fullwidth-symbols-datas.ts
@@ -36,7 +36,7 @@ const DemoFullWidthSymbolDataFields: any = {
         code: "＿",
         required: "false",
         defaultValue: "",
-    }
+    },
 };
 
 const DemoFullWidthSymbolRecord: any = {

--- a/src/templates/expressions/fields.test.ts
+++ b/src/templates/expressions/fields.test.ts
@@ -15,7 +15,66 @@ describe("StringField", () => {
                 .trim()
         ).toEqual(
             `
-fieldName : {
+"fieldName" : {
+    type: "SINGLE_LINE";
+    value: string;
+    error?: string;
+};`.trim()
+        );
+    });
+});
+
+describe("StringField with Full Width Symbol FieldCode", () => {
+    test("toTsExpression() with ・", () => {
+        expect(
+            new StringField("・", "SINGLE_LINE")
+                .tsExpression()
+                .trim()
+        ).toEqual(
+            `
+"・" : {
+    type: "SINGLE_LINE";
+    value: string;
+    error?: string;
+};`.trim()
+        );
+    });
+    test("toTsExpression() with ￥", () => {
+        expect(
+            new StringField("￥", "SINGLE_LINE")
+                .tsExpression()
+                .trim()
+        ).toEqual(
+            `
+"￥" : {
+    type: "SINGLE_LINE";
+    value: string;
+    error?: string;
+};`.trim()
+        );
+    });
+    test("toTsExpression() with ＿", () => {
+        expect(
+            new StringField("＿", "SINGLE_LINE")
+                .tsExpression()
+                .trim()
+        ).toEqual(
+            `
+"＿" : {
+    type: "SINGLE_LINE";
+    value: string;
+    error?: string;
+};`.trim()
+        );
+    });
+    test("toTsExpression() with ＄", () => {
+        expect(
+            new StringField("＄", "SINGLE_LINE")
+                .tsExpression()
+                .trim()
+        ).toEqual(
+            `
+"＄" : {
     type: "SINGLE_LINE";
     value: string;
     error?: string;
@@ -32,7 +91,7 @@ describe("StringListField", () => {
                 .trim()
         ).toEqual(
             `
-fieldName : {
+"fieldName" : {
     type: "CHECK_BOX";
     value: string[];
     error?: string;
@@ -49,7 +108,7 @@ describe("EntityListField", () => {
                 .trim()
         ).toEqual(
             `
-fieldName : {
+"fieldName" : {
     type: "USER_SELECT";
     value: {code: string, name: string}[];
     error?: string;
@@ -71,7 +130,7 @@ describe("SubTableField", () => {
                 .trim()
         ).toEqual(
             `
-fieldName : {
+"fieldName" : {
     type: "SUBTABLE";
     value: {
         id: string;
@@ -92,7 +151,7 @@ describe("FileField", () => {
                 .trim()
         ).toEqual(
             `
-fieldName : {
+"fieldName" : {
     type: "FILE";
     value: {
         contentType: string;
@@ -138,27 +197,27 @@ describe("FieldGroup", () => {
                 .trim()
         ).toEqual(
             `
-fieldName1 : {
+"fieldName1" : {
     type: "SINGLE_STRING_LINE";
     value: string;
     error?: string;
 };
-fieldName2 : {
+"fieldName2" : {
     type: "SINGLE_STRING_LINE";
     value: string;
     error?: string;
 };
-fieldName3 : {
+"fieldName3" : {
     type: "MULTI_CHECK";
     value: string[];
     error?: string;
 };
-fieldName4 : {
+"fieldName4" : {
     type: "USER_SELECT";
     value: {code: string, name: string}[];
     error?: string;
 };
-fieldName5 : {
+"fieldName5" : {
     type: "FILE";
     value: {
         contentType: string;

--- a/src/templates/expressions/fields.ts
+++ b/src/templates/expressions/fields.ts
@@ -29,7 +29,7 @@ export class StringField implements TsExpression {
 
     tsExpression(): string {
         return `
-${this.fieldName} : {
+"${this.fieldName}" : {
     type: "${this.fieldType}";
     value: string;
     error?: string;
@@ -44,7 +44,7 @@ export class StringListField implements TsExpression {
     ) {}
     tsExpression(): string {
         return `
-${this.fieldName} : {
+"${this.fieldName}" : {
     type: "${this.fieldType}";
     value: string[];
     error?: string;
@@ -63,7 +63,7 @@ export class UserField implements TsExpression {
      */
     tsExpression(): string {
         return `
-${this.fieldName} : {
+"${this.fieldName}" : {
     type: "${this.fieldType}";
     value: {code: string, name: string}; 
 };`.trim();
@@ -77,7 +77,7 @@ export class EntityListField implements TsExpression {
     ) {}
     tsExpression(): string {
         return `
-${this.fieldName} : {
+"${this.fieldName}" : {
     type: "${this.fieldType}";
     value: {code: string, name: string}[];
     error?: string;
@@ -92,7 +92,7 @@ export class FileField implements TsExpression {
     ) {}
     tsExpression(): string {
         return `
-${this.fieldName} : {
+"${this.fieldName}" : {
     type: "${this.fieldType}";
     value: {
         contentType: string;
@@ -113,7 +113,7 @@ export class SubTableField implements TsExpression {
     ) {}
     tsExpression(): string {
         return `
-${this.fieldName} : {
+"${this.fieldName}" : {
     type: "${this.fieldType}";
     value: {
         id: string;

--- a/src/templates/template.test.ts
+++ b/src/templates/template.test.ts
@@ -1,6 +1,6 @@
 import { TypeDefinitionTemplate as t } from "./template";
 import { DemoClient } from "../kintone/clients/demo-client";
-import { DemoFullWidthSymbolClient } from "../kintone/clients/demo-fullwidth-symbol-client"
+import { DemoFullWidthSymbolClient } from "../kintone/clients/demo-fullwidth-symbol-client";
 import { FieldTypeConverter } from "../converters/fileldtype-converter";
 import { objectValues } from "../utils/objectvalues";
 import * as fs from "fs";
@@ -75,7 +75,9 @@ describe("fullWidthSymbol Test", () => {
         t.renderAsFile(TEMP_TEST_TYPEDEF, input);
 
         const expected = fs
-            .readFileSync("./resources/test-fullwidth-symbol-field.d.ts")
+            .readFileSync(
+                "./resources/test-fullwidth-symbol-field.d.ts"
+            )
             .toString()
             .trim()
             .replace(/\r?\n/g, "");

--- a/src/templates/template.test.ts
+++ b/src/templates/template.test.ts
@@ -1,5 +1,6 @@
 import { TypeDefinitionTemplate as t } from "./template";
 import { DemoClient } from "../kintone/clients/demo-client";
+import { DemoFullWidthSymbolClient } from "../kintone/clients/demo-fullwidth-symbol-client"
 import { FieldTypeConverter } from "../converters/fileldtype-converter";
 import { objectValues } from "../utils/objectvalues";
 import * as fs from "fs";
@@ -27,6 +28,54 @@ describe("renderAsFile", () => {
 
         const expected = fs
             .readFileSync("./resources/testfield.d.ts")
+            .toString()
+            .trim()
+            .replace(/\r?\n/g, "");
+
+        const actual = fs
+            .readFileSync(TEMP_TEST_TYPEDEF)
+            .toString()
+            .trim()
+            .replace(/\r?\n/g, "");
+
+        expect(actual.toString().trim()).toEqual(
+            expected.toString().trim()
+        );
+    });
+
+    afterEach(() => {
+        fs.unlink(TEMP_TEST_TYPEDEF, err => {
+            if (err) {
+                throw err;
+            }
+        });
+    });
+});
+
+describe("fullWidthSymbol Test", () => {
+    const TEMP_TEST_TYPEDEF = "tmp.testfield.d.ts";
+    test("generate typedefinition file", async () => {
+        const client = new DemoFullWidthSymbolClient();
+        const fieldTypeGroups = await client
+            .fetchFormProperties({
+                appId: "",
+                preview: false,
+                guestSpaceId: null,
+            })
+            .then(properties =>
+                FieldTypeConverter.convertFieldTypesToFieldTypeGroups(
+                    objectValues(properties)
+                )
+            );
+        const input = {
+            typeName: "TestFields",
+            namespace: "kintone.types",
+            fieldTypeGroups,
+        };
+        t.renderAsFile(TEMP_TEST_TYPEDEF, input);
+
+        const expected = fs
+            .readFileSync("./resources/test-fullwidth-symbol-field.d.ts")
             .toString()
             .trim()
             .replace(/\r?\n/g, "");


### PR DESCRIPTION
kintoneのフィールドコードには一部の全角の記号(「・」「＿」「￥」「＄」)を使用することが許されている。
https://jp.cybozu.help/k/en/user/app_settings/form/fieldcode.html

しかしそれらがフィールドコードに含まれていると、生成されるfield.d.tsの中のプロパティの名前に使用することが許されていない文字がプロパティ名に使われてしまいSyntax Errorとなる。
そのためprettierでフォーマットする時にクラッシュしてしまう。

明示的にプロパティ名をダブルクォートで括ることでSyntax Errorのないfield.d.tsを生成するように修正。

