### PR TITLE
build(ci): Run all required checks on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ commands:
             - node_modules
           key: v1-dependencies-{{ checksum "package-lock.json" }}
       # run tests!
+      - run: npm run tsc:check
       - run: npm run lint
+      - run: npm run prettier:check
+      - run: npm run build:integration
       - run: npm test
 jobs:
   node-v8:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "bin/npm-build.sh",
     "tsc": "tsc",
+    "tsc:check": "tsc --noEmit",
     "clean": "rm -rfv dist",
     "lint:fix": "eslint --fix src/**/*.ts",
     "lint": "eslint src/**/*.ts",

--- a/src/integration-tests/setup-test-utils.ts
+++ b/src/integration-tests/setup-test-utils.ts
@@ -49,9 +49,7 @@ async function uploadFile(
         })
         .then(resp => {
             log(
-                `Finish Uploading ${metadata.name}(${
-                    resp.fileKey
-                })`
+                `Finish Uploading ${metadata.name}(${resp.fileKey})`
             );
             return resp.fileKey;
         })

--- a/src/kintone/clients/axios-utils.ts
+++ b/src/kintone/clients/axios-utils.ts
@@ -40,9 +40,7 @@ function newAxiosInstance(
         headers["Authorization"] =
             "Basic " +
             Buffer.from(
-                `${input.basicAuthUsername}:${
-                    input.basicAuthPassword
-                }`
+                `${input.basicAuthUsername}:${input.basicAuthPassword}`
             ).toString("base64");
     }
     return VisibleForTesting.newAxiosInstanceInternal({


### PR DESCRIPTION
We should verify these checks on CI because passing the checks is necessary to run `npm run build`.